### PR TITLE
v0.1.1: add Russian translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ For the web app, you should drop the `.ttf` files (unzipped from the linked down
     - titlepage keywords?
   - [x] English
   - [x] Finnish
+  - [x] Russian
 - [ ] Write documentation for all functionality
 - [x] Write examples you are allowed to share
 - [x] Write packaging TOML

--- a/scriptie.typ
+++ b/scriptie.typ
@@ -15,7 +15,7 @@
   *#underline(title)*
 
   #v(1em)
-  by
+  #translations.at(text.lang).written-by
   #v(-0.5em)
   #author.join("\n")
   #v(0.5em)

--- a/translations.typ
+++ b/translations.typ
@@ -27,5 +27,13 @@
     date-format:"[day].[month].[year]",
     file-keywords: ("elokuva","filmi","käsikirjoitus","kässäri"),
     contd: "JATK.",
-  )
+  ),
+  ru: (
+    written-by: "за авторством",
+    default-title: "Безымянный сценарий",
+    part-title: "Часть",
+    date-format:"[year]-[month]-[day]",
+    file-keywords: ("фильм","кино","сценарий"),
+    contd: "ПРОДОЛЖАЕТ",
+  ),
 )

--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scriptie"
-version = "0.1.0"
+version = "0.1.1"
 entrypoint = "scriptie.typ"
 authors = ["Kauri P"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
This PR adds Russian language support to the translations and fixes an issue with the `by` label in the template.

**Changes**
- Added Russian (ru) translations, including all required fields.
- Replaced the hardcoded by label with a localized written-by key to ensure proper internationalization.
- Version bumped to `0.1.1`.

Let me know if any adjustments are needed. @KauriP, can you take a look?